### PR TITLE
Prettier dump on write mismatch (hex + diff)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,10 @@ impl Inner {
                 Action::Write(ref mut expect) => {
                     let n = cmp::min(src.len(), expect.len());
 
-                    assert_eq!(&src[..n], &expect[..n]);
+                    assert_eq!(&src[..n], &expect[..n],
+                               "\n hex written: {:02x?}\nhex expected: {:02x?}\n        DIFF:  {}^^",
+                               &src[..n], &expect[..n],
+                               "    ".repeat(src[..n].iter().zip(expect[..n].iter()).position(|(&x,&y)| x != y).unwrap()));
 
                     // Drop data that was matched
                     expect.drain(..n);


### PR DESCRIPTION
Sample output:

```
running 1 test
test existing_pkg_iodump ... FAILED

failures:

---- existing_pkg_iodump stdout ----
thread 'existing_pkg_iodump' panicked at 'assertion failed: `(left == right)`
  left: `[104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]`,
 right: `[203, 238, 82, 84, 0, 0, 0, 0, 4, 2, 0]`: 
 hex written: [68, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64]
hex expected: [cb, ee, 52, 54, 00, 00, 00, 00, 04, 02, 00]
        DIFF:  ^^', /home/akavel/.cargo/git/checkouts/mock-io-4a9c6b3ff6c2f637/00444b0/src/lib.rs:235:21
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```