### PR TITLE
fix compile errors that occur when the tokio feature is disabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,11 +510,11 @@ mod tokio {
     #[derive(Debug, Default)]
     pub struct TokioInner;
 
-    fn async_read(_: &mut Mock, _: &mut [u8]) -> io::Result<usize> {
+    pub fn async_read(_: &mut Mock, _: &mut [u8]) -> io::Result<usize> {
         unreachable!();
     }
 
-    fn async_write(_: &mut Mock, _: &[u8]) -> io::Result<usize> {
+    pub fn async_write(_: &mut Mock, _: &[u8]) -> io::Result<usize> {
         unreachable!();
     }
 

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "tokio")]
+
 extern crate mock_io;
 
 extern crate futures;


### PR DESCRIPTION
It fixes #1 and (possibly) the CI failures in #2.